### PR TITLE
Fix bug with workingDiff returning incorrect arity when called with 'days'

### DIFF
--- a/lib/business-hours.js
+++ b/lib/business-hours.js
@@ -236,7 +236,7 @@ moment.fn.workingDiff = function workingDiff(comparator, unit, detail) {
 
     while(from.format('L') !== to.format('L')) {
         if (unit === 'day') {
-            diff++;
+            diff--;
         } else {
             diff += from.diff(openingTimes(from)[1], unit, true);
         }
@@ -244,7 +244,7 @@ moment.fn.workingDiff = function workingDiff(comparator, unit, detail) {
     }
 
     if (unit === 'day') {
-        diff++;
+        diff--;
     } else {
         diff += from.diff(to, unit, true);
     }

--- a/test/spec.business-hours.js
+++ b/test/spec.business-hours.js
@@ -387,8 +387,8 @@ describe('moment.business-hours', function () {
             var from = moment('2015-02-27T10:00:00'),
                 to = moment('2015-03-20T13:30:00');
 
-            from.workingDiff(to, 'days').should.equal(16);
-            to.workingDiff(from, 'days').should.equal(-16);
+            from.workingDiff(to, 'days').should.equal(-16);
+            to.workingDiff(from, 'days').should.equal(16);
         });
 
         it('handles units that don\'t really makes sense for business opening times by deferring to moment', function () {


### PR DESCRIPTION
The sign of the returned value was incorrectly reversed when calling with a unit of 'days'.

Fixes #8
