### PR TITLE
Fix for no holiday definition.

### DIFF
--- a/lib/business-hours.js
+++ b/lib/business-hours.js
@@ -175,11 +175,14 @@ moment.fn.isWorkingTime = function isWorkingTime() {
 moment.fn.isHoliday = function isHoliday() {
     var isHoliday = false,
         today = this.format('YYYY-MM-DD');
-    getLocaleData('holidays').forEach(function (holiday) {
-        if (minimatch(today, holiday)) {
-            isHoliday = true;
-        }
-    });
+    var holidays = getLocaleData('holidays')
+    if(holidays){
+        holidays.forEach(function (holiday) {
+            if (minimatch(today, holiday)) {
+                isHoliday = true;
+            }
+        });
+    }
     return isHoliday;
 };
 


### PR DESCRIPTION
If no holiday is defined when initiating,  workingtimediff is throwing error. this commit fixing the issue.