### PR TITLE
feature: support for openings and closings (lunch time) throughout the day

### DIFF
--- a/lib/business-hours.js
+++ b/lib/business-hours.js
@@ -165,11 +165,14 @@ moment.fn.isWorkingDay = moment.fn.isBusinessDay;
 
 moment.fn.isWorkingTime = function isWorkingTime() {
     var openinghours = openingTimes(this);
-    if (!openinghours) {
-        return false;
-    } else {
-        return this.isSameOrAfter(openinghours[0]) && this.isSameOrBefore(openinghours[1]);
+    if (openinghours) {
+        for (let i = 0; i < openinghours.length; i += 2) {
+            if (this.isSameOrAfter(openinghours[i]) && this.isSameOrBefore(openinghours[i + 1])) {
+                return true;
+            }
+        }
     }
+    return false;
 };
 
 moment.fn.isHoliday = function isHoliday() {

--- a/lib/business-hours.js
+++ b/lib/business-hours.js
@@ -166,7 +166,7 @@ moment.fn.isWorkingDay = moment.fn.isBusinessDay;
 moment.fn.isWorkingTime = function isWorkingTime() {
     var openinghours = openingTimes(this);
     if (openinghours) {
-        for (let i = 0; i < openinghours.length; i += 2) {
+        for (var i = 0; i < openinghours.length; i += 2) {
             if (this.isSameOrAfter(openinghours[i]) && this.isSameOrBefore(openinghours[i + 1])) {
                 return true;
             }

--- a/lib/business-hours.js
+++ b/lib/business-hours.js
@@ -177,12 +177,16 @@ moment.fn.isWorkingTime = function isWorkingTime() {
 
 moment.fn.isHoliday = function isHoliday() {
     var isHoliday = false,
-        today = this.format('YYYY-MM-DD');
-    getLocaleData('holidays').forEach(function (holiday) {
-        if (minimatch(today, holiday)) {
-            isHoliday = true;
-        }
-    });
+        today = this.format('YYYY-MM-DD'),
+        holidays = getLocaleData('holidays');
+
+    if (holidays) {
+        holidays.forEach(function (holiday) {
+            if (minimatch(today, holiday)) {
+                isHoliday = true;
+            }
+        });
+    }
     return isHoliday;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moment-business-time",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Query and manipulate moment objects within the context of business/working hours",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "minimatch": "^3.0.3",
-    "moment": "^2.14.1"
+    "moment": "^2.24.0"
   },
   "devDependencies": {
     "chai": "^2.1.0",

--- a/test/spec.business-hours.js
+++ b/test/spec.business-hours.js
@@ -58,6 +58,27 @@ describe('moment.business-hours', function () {
              moment('2017-06-26 17:00:00').isWorkingTime().should.be.true;
         });
 
+        it('considers multiple working times', function(){
+            moment.locale('en', {
+                workinghours: {
+                    0: null,
+                    1: ['09:00:00', '17:00:00', '18:00:00', '23:00:00'],
+                    2: ['09:00:00', '17:00:00', '18:00:00', '23:00:00'],
+                    3: ['09:00:00', '17:00:00', '18:00:00', '23:00:00'],
+                    4: ['09:00:00', '17:00:00', '18:00:00', '23:00:00'],
+                    5: ['09:00:00', '17:00:00', '18:00:00', '23:00:00'],
+                    6: null
+                }
+            });
+
+            moment('2017-06-26 16:45:00').isWorkingTime().should.be.true;
+            moment('2017-06-26 17:00:00').isWorkingTime().should.be.true;
+            moment('2017-06-26 17:15:00').isWorkingTime().should.be.false;
+            moment('2017-06-26 17:45:00').isWorkingTime().should.be.false;
+            moment('2017-06-26 18:00:00').isWorkingTime().should.be.true;
+            moment('2017-06-26 18:15:00').isWorkingTime().should.be.true;
+        });
+
     });
 
     describe('nextWorkingDay', function () {


### PR DESCRIPTION
This allows for business times to be defined with opening and closings throughout the same day. This is useful for breaks such as lunch times, or in our case businesses that are open past midnight but when then reopen again in the afternoon.

This is not a breaking change, everything continues to work as is but allows for opening times to be defined in sets of two (`[ open, close, open, close ]`).