### PR TITLE
Bugfix: Loss of locale due to getLocaleData

### DIFF
--- a/lib/business-hours.js
+++ b/lib/business-hours.js
@@ -4,13 +4,9 @@ var moment = require('moment'),
 var localeData = require('../locale/default');
 moment.updateLocale(moment.locale(), localeData);
 
-function getLocaleData(key) {
-    return moment.localeData()['_' + key];
-}
-
 function openingTimes(d) {
     d = d.clone();
-    var hours = getLocaleData('workinghours');
+    var hours = d.localeData()['_workinghours'];
     if (!d.isWorkingDay()) {
         return null;
     }
@@ -191,7 +187,7 @@ moment.fn.addWorkingTime = addOrSubtractMethod(add);
 moment.fn.subtractWorkingTime = addOrSubtractMethod(subtract);
 
 moment.fn.isBusinessDay = function isBusinessDay() {
-    var hours = getLocaleData('workinghours');
+    var hours = this.localeData()['_workinghours'];
     return !!hours[this.day()] && !this.isHoliday();
 };
 moment.fn.isWorkingDay = moment.fn.isBusinessDay;
@@ -211,7 +207,7 @@ moment.fn.isWorkingTime = function isWorkingTime() {
 moment.fn.isHoliday = function isHoliday() {
     var isHoliday = false,
         today = this.format('YYYY-MM-DD');
-    (getLocaleData('holidays') || []).forEach(function (holiday) {
+    (this.localeData()['_holidays'] || []).forEach(function (holiday) {
         if (minimatch(today, holiday)) {
             isHoliday = true;
         }

--- a/lib/business-hours.js
+++ b/lib/business-hours.js
@@ -263,18 +263,14 @@ moment.fn.nextWorkingTime = function nextWorkingTime() {
 moment.fn.nextTransitionTime = function nextTransitionTime() {
     if (this.isWorkingDay()) {
         var segments = openingTimes(this);
-        var openinghours, lastSegment;
+        var openinghours;
         for (var i = 0; i < segments.length; i++) {
             openinghours = segments[i];
-            lastSegment = i === segments.length -1;
             if (this.isBefore(openinghours[0])) {
                 return {'transition': 'open','moment':openinghours[0]};
             } else if (this.isBefore(openinghours[1])) {
                 return {'transition':'close','moment':openinghours[1]};
             } else if (this.isAfter(openinghours[1])) {
-                if (!lastSegment) {
-                    continue;
-                }
                 return {'transition':'open','moment':openingTimes(this.nextWorkingDay())[0][0]};
             }
         }

--- a/lib/business-hours.js
+++ b/lib/business-hours.js
@@ -240,16 +240,12 @@ moment.fn.lastWorkingDay = function nextWorkingDay() {
 moment.fn.nextWorkingTime = function nextWorkingTime() {
     if (this.isWorkingDay()) {
         var segments = openingTimes(this);
-        var openinghours, lastSegment;
+        var openinghours;
         for (var i = 0; i < segments.length; i++) {
             openinghours = segments[i];
-            lastSegment = i === segments.length -1;
             if (this.isBefore(openinghours[0])) {
                 return openinghours[0];
             } else if (this.isAfter(openinghours[1])) {
-                if (!lastSegment) {
-                    continue;
-                }
                 return openingTimes(this.nextWorkingDay())[0][0];
             } else {
                 return this.clone();

--- a/lib/business-hours.js
+++ b/lib/business-hours.js
@@ -240,12 +240,16 @@ moment.fn.lastWorkingDay = function nextWorkingDay() {
 moment.fn.nextWorkingTime = function nextWorkingTime() {
     if (this.isWorkingDay()) {
         var segments = openingTimes(this);
-        var openinghours;
+        var openinghours, lastSegment;
         for (var i = 0; i < segments.length; i++) {
             openinghours = segments[i];
+            lastSegment = i === segments.length -1;
             if (this.isBefore(openinghours[0])) {
                 return openinghours[0];
             } else if (this.isAfter(openinghours[1])) {
+                if (!lastSegment) {
+                    continue;
+                }
                 return openingTimes(this.nextWorkingDay())[0][0];
             } else {
                 return this.clone();
@@ -255,6 +259,7 @@ moment.fn.nextWorkingTime = function nextWorkingTime() {
         return openingTimes(this.nextWorkingDay())[0][0];
     }
 };
+
 
 moment.fn.nextTransitionTime = function nextTransitionTime() {
     if (this.isWorkingDay()) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moment-business-time",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "description": "Query and manipulate moment objects within the context of business/working hours",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moment-business-time",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Query and manipulate moment objects within the context of business/working hours",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hello, when we want to use multiple configurations of "workinghours", we need to use the locale, but since getLocaleData refers to "moment" at the global level, the configuration is lost by calling the nextTransitionTime, isBusinessDay, isWorkingDay and isHoliday methods... (I advise you to check the behavior of each method).

```
// Here is my test code
bugfix() {
	console.log(moment.localeData()._workinghours); // Return the default configuration

	moment.updateLocale("test", {workinghours: {0: ['04:00:00', '20:00:00'], 1: ['04:00:00', '20:00:00'], 2: ['04:00:00', '20:00:00'], 3: ['04:00:00', '20:00:00'], 4: null, 5: null, 6: null}});
	moment.locale("en"); // To keep the default English locale

	let startMoment = moment().locale("test").nextWorkingTime();
	let endMoment = startMoment.nextTransitionTime().moment;
	console.log(endMoment.toDate()); // Fail
}
```