### PR TITLE
Add "calendar day" working diff

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,23 @@
+on:
+  - pull_request
+  - push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version:
+          - 14.x
+          - 16.x
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -183,6 +183,43 @@ moment('2015-02-27T16:30:00Z').workingDiff(moment('2015-02-26T12:00:00Z'), 'hour
 // 12.5
 ```
 
+#### Note on `day` in `workingDiff`
+
+When `workingDiff` passed a unit of `days` it will use the times provided to calculate the number of _complete_ working days based on the working hours specified in the locale (default `09:00-17:00, Mon-Fri`). This means that a diff of 1 day can be returned for values on the same day if the timestamps fully contain the day's working hours.
+
+Examples:
+
+```javascript
+moment('2022-01-11T09:30:00Z').workingDiff(moment('2022-01-10T10:00:00Z'), 'days');
+// 0
+moment('2022-01-11T10:30:00Z').workingDiff(moment('2022-01-10T10:00:00Z'), 'days');
+// 1
+moment('2022-01-11T16:00:00Z').workingDiff(moment('2022-01-10T08:00:00Z'), 'days');
+// 1
+moment('2022-01-11T18:00:00Z').workingDiff(moment('2022-01-10T08:00:00Z'), 'days');
+// 2
+moment('2022-01-12T18:00:00Z').workingDiff(moment('2022-01-10T08:00:00Z'), 'days');
+// 3
+```
+
+Alternatively, if you wish to disregard the time of day consider only the calendar days, then a unit of `calendarDays` can be passed. For periods that do not contain any non-working days this is equivalent to `moment#diff(..., 'days')`.
+
+Examples:
+
+```javascript
+moment('2022-01-11T09:30:00Z').workingDiff(moment('2022-01-10T10:00:00Z'), 'days');
+// 1
+moment('2022-01-11T10:30:00Z').workingDiff(moment('2022-01-10T10:00:00Z'), 'days');
+// 1
+moment('2022-01-11T16:00:00Z').workingDiff(moment('2022-01-10T08:00:00Z'), 'days');
+// 1
+moment('2022-01-11T18:00:00Z').workingDiff(moment('2022-01-10T08:00:00Z'), 'days');
+// 1
+moment('2022-01-12T18:00:00Z').workingDiff(moment('2022-01-10T08:00:00Z'), 'days');
+// 2
+```
+
+
 ## Configuration
 
 ### Working hours

--- a/lib/business-hours.js
+++ b/lib/business-hours.js
@@ -196,11 +196,15 @@ moment.fn.isBusinessDay = function isBusinessDay() {
 };
 moment.fn.isWorkingDay = moment.fn.isBusinessDay;
 
-moment.fn.isWorkingTime = function isWorkingTime() {
+moment.fn.isWorkingTime = function isWorkingTime(opts) {
+    const { ignoreBreaks } = opts || {};
     var segments = openingTimes(this);
     if (!segments) {
         return false;
     } else {
+        if (ignoreBreaks) {
+            segments = [[ segments[0][0], segments.pop()[1] ]];
+        }
         var self = this;
         return segments.some(function(openinghours) {
             return self.isSameOrAfter(openinghours[0]) && self.isSameOrBefore(openinghours[1]);
@@ -331,13 +335,13 @@ moment.fn.lastTransitionTime = function lastTransitionTime() {
 
 moment.fn.workingDiff = function workingDiff(comparator, unit, detail) {
     unit = unit || 'milliseconds';
-    unit = moment.normalizeUnits(unit);
-
+    unit = unit.match(/^calendarDay(s?)$/) ? 'calendarDay' : moment.normalizeUnits(unit);
     comparator = moment(comparator);
 
     if (['year', 'month', 'week'].indexOf(unit) > -1) {
         return this.diff(comparator, unit, detail);
     }
+
 
     // ensure `from` is always before `to`
     var from, to, diff = 0, multiplier = 1;
@@ -349,14 +353,18 @@ moment.fn.workingDiff = function workingDiff(comparator, unit, detail) {
         to = comparator.clone();
         from = this.clone();
     }
+    if (unit === 'calendarDay') {
+        from = from.startOf('day');
+        to = to.startOf('day');
+    } else {
+        if (!from.isWorkingTime({ ignoreBreaks: true })) {
+            from = from.nextWorkingTime();
+        }
+        if (!to.isWorkingTime({ ignoreBreaks: true })) {
+            to = to.lastWorkingTime();
+        }
+    }
 
-    // normalise to nearest working times
-    if (!from.isWorkingTime()) {
-        from = from.nextWorkingTime();
-    }
-    if (!to.isWorkingTime()) {
-        to = to.lastWorkingTime();
-    }
 
     // if `from` is now after `to` then we have two timestamps on the same night, so diff is zero
     if (from.isAfter(to)) {
@@ -364,12 +372,18 @@ moment.fn.workingDiff = function workingDiff(comparator, unit, detail) {
     }
 
     if (unit === 'day') {
-        // iterate to the same day
-        while(!from.isSame(to, 'day')) {
+        if (!from.isAfter(openingTimes(from)[0][0]) && !to.isBefore(openingTimes(to).pop()[1])) {
             diff--;
-            from = from.addWorkingTime(1, 'day');
         }
-        if (detail) {
+    }
+
+    if (unit === 'day' || unit === 'calendarDay') {
+        // iterate to the same day
+        while(!from.clone().addWorkingTime(1, 'day').isAfter(to)) {
+            diff--;
+            from.addWorkingTime(1, 'day');
+        }
+        if (detail && unit === 'day') {
             if (process.env.NODE_ENV !== 'production') {
                 console.warn('WARNING: passing `true` as a third argument to `workingDiff` may lead to ambiguous results');
                 console.warn('See https://github.com/lennym/moment-business-time/issues/12#issuecomment-199710566');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Query and manipulate moment objects within the context of business/working hours",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test/. --require test/init.js"
+    "test": "mocha test/. --require test/init.js --timeout 10000"
   },
   "repository": {
     "type": "git",

--- a/test/spec.business-hours.js
+++ b/test/spec.business-hours.js
@@ -1,6 +1,10 @@
 var moment = require('../lib/business-hours');
 var localeData = require('../locale/default');
 
+const randomDate = () => {
+    return moment(1e12 + Math.floor(Math.random() * 1e12));
+}
+
 describe('moment.business-hours', function () {
 
     var now = '2015-02-26T10:12:34',
@@ -622,6 +626,225 @@ describe('moment.business-hours', function () {
 
         it('returns zero for times on the same night over consecutive days', function () {
             moment('2016-10-16T18:00:00+00:00').workingDiff('2016-10-17T06:00:00+00:00', 'hours').should.equal(0);
+        });
+
+        describe('days', () => {
+
+            it('if the start time is before business hours', () => {
+                const start  = moment('2021-11-22T08:00:00'); // Monday morning
+
+                // same day, during the day
+                moment('2021-11-22T16:00:00').workingDiff(start, 'days').should.equal(0);
+                // same day, after close of business
+                moment('2021-11-22T18:00:00').workingDiff(start, 'days').should.equal(1);
+                // next day, before start of business
+                moment('2021-11-23T08:00:00').workingDiff(start, 'days').should.equal(1);
+                // next day, during the day
+                moment('2021-11-23T14:00:00').workingDiff(start, 'days').should.equal(1);
+                // next day, after close of business
+                moment('2021-11-23T19:00:00').workingDiff(start, 'days').should.equal(2);
+                // friday night
+                moment('2021-11-26T19:00:00').workingDiff(start, 'days').should.equal(5);
+                // saturday night
+                moment('2021-11-27T19:00:00').workingDiff(start, 'days').should.equal(5);
+                // sunday night
+                moment('2021-11-28T19:00:00').workingDiff(start, 'days').should.equal(5);
+                // next monday
+                moment('2021-11-29T11:00:00').workingDiff(start, 'days').should.equal(5);
+                moment('2021-11-29T18:00:00').workingDiff(start, 'days').should.equal(6);
+            });
+
+            it('if the start time is during business hours', () => {
+                const start  = moment('2021-11-22T11:00:00'); // Monday morning
+
+                // same day, during the day
+                moment('2021-11-22T16:00:00').workingDiff(start, 'days').should.equal(0);
+                // same day, after close of business
+                moment('2021-11-22T18:00:00').workingDiff(start, 'days').should.equal(0);
+                // next day, before start of business
+                moment('2021-11-23T08:00:00').workingDiff(start, 'days').should.equal(0);
+                // next day, during the day
+                moment('2021-11-23T10:00:00').workingDiff(start, 'days').should.equal(0);
+                moment('2021-11-23T14:00:00').workingDiff(start, 'days').should.equal(1);
+                // next day, after close of business
+                moment('2021-11-23T19:00:00').workingDiff(start, 'days').should.equal(1);
+                // subsequent day, during day
+                moment('2021-11-24T10:00:00').workingDiff(start, 'days').should.equal(1);
+                moment('2021-11-24T14:00:00').workingDiff(start, 'days').should.equal(2);
+                // subsequent day, after close of business
+                moment('2021-11-24T19:00:00').workingDiff(start, 'days').should.equal(2);
+                // friday night
+                moment('2021-11-26T19:00:00').workingDiff(start, 'days').should.equal(4);
+                // saturday night
+                moment('2021-11-27T19:00:00').workingDiff(start, 'days').should.equal(4);
+                // sunday night
+                moment('2021-11-28T19:00:00').workingDiff(start, 'days').should.equal(4);
+                // next monday
+                moment('2021-11-29T10:00:00').workingDiff(start, 'days').should.equal(4);
+                moment('2021-11-29T12:00:00').workingDiff(start, 'days').should.equal(5);
+                moment('2021-11-29T18:00:00').workingDiff(start, 'days').should.equal(5);
+            });
+
+            it('if the start time is after business hours', () => {
+                const start  = moment('2021-11-22T19:00:00'); // Monday morning
+
+                // same day, after close of business
+                moment('2021-11-22T20:00:00').workingDiff(start, 'days').should.equal(0);
+                // next day, before start of business
+                moment('2021-11-23T08:00:00').workingDiff(start, 'days').should.equal(0);
+                // next day, during the day
+                moment('2021-11-23T14:00:00').workingDiff(start, 'days').should.equal(0);
+                // next day, after close of business
+                moment('2021-11-23T19:00:00').workingDiff(start, 'days').should.equal(1);
+                // friday night
+                moment('2021-11-26T19:00:00').workingDiff(start, 'days').should.equal(4);
+                // saturday night
+                moment('2021-11-27T19:00:00').workingDiff(start, 'days').should.equal(4);
+                // sunday night
+                moment('2021-11-28T19:00:00').workingDiff(start, 'days').should.equal(4);
+                // next monday
+                moment('2021-11-29T11:00:00').workingDiff(start, 'days').should.equal(4);
+                moment('2021-11-29T18:00:00').workingDiff(start, 'days').should.equal(5);
+            });
+
+            it('if the start time is during a break', () => {
+                moment.locale('en', {
+                    workinghours:  {
+                        0: null,
+                        1: ['09:30:00', '12:00:00', '13:00:00', '17:00:00'],
+                        2: ['09:30:00', '12:00:00', '13:00:00', '17:00:00'],
+                        3: ['09:30:00', '12:00:00', '13:00:00', '17:00:00'],
+                        4: ['09:30:00', '12:00:00', '13:00:00', '17:00:00'],
+                        5: ['09:30:00', '12:00:00', '13:00:00', '17:00:00'],
+                        6: null
+                    }
+                });
+                const start  = moment('2021-11-22T12:30:00'); // Monday morning
+                start.isWorkingTime({ ignoreBreaks: true }).should.equal(true);
+                // same day, during the day
+                moment('2021-11-22T16:00:00').workingDiff(start, 'days').should.equal(0);
+                // same day, after close of business
+                moment('2021-11-22T18:00:00').workingDiff(start, 'days').should.equal(0);
+                // next day, before start of business
+                moment('2021-11-23T08:00:00').workingDiff(start, 'days').should.equal(0);
+                // next day, during a break
+                moment('2021-11-23T12:45:00').workingDiff(start, 'days').should.equal(1);
+                // next day, during the day
+                moment('2021-11-23T14:00:00').workingDiff(start, 'days').should.equal(1);
+                // next day, after close of business
+                moment('2021-11-23T14:00:00').workingDiff(start, 'days').should.equal(1);
+            });
+
+        });
+
+        describe('calendarDays', () => {
+            it('when start point is before opening on a working day', () => {
+                const start  = moment('2021-11-22T08:00:00'); // Monday morning
+
+                // same day, during the day
+                moment('2021-11-22T16:00:00').workingDiff(start, 'calendarDays').should.equal(0);
+                // same day, after close of business
+                moment('2021-11-22T18:00:00').workingDiff(start, 'calendarDays').should.equal(0);
+                // next day, before start of business
+                moment('2021-11-23T08:00:00').workingDiff(start, 'calendarDays').should.equal(1);
+                // next day, during the day
+                moment('2021-11-23T14:00:00').workingDiff(start, 'calendarDays').should.equal(1);
+                // next day, after close of business
+                moment('2021-11-23T19:00:00').workingDiff(start, 'calendarDays').should.equal(1);
+                // friday night
+                moment('2021-11-26T19:00:00').workingDiff(start, 'calendarDays').should.equal(4);
+                // saturday night
+                moment('2021-11-27T19:00:00').workingDiff(start, 'calendarDays').should.equal(4);
+                // sunday night
+                moment('2021-11-28T19:00:00').workingDiff(start, 'calendarDays').should.equal(4);
+                // next monday
+                moment('2021-11-29T11:00:00').workingDiff(start, 'calendarDays').should.equal(5);
+                moment('2021-11-29T18:00:00').workingDiff(start, 'calendarDays').should.equal(5);
+            });
+
+            it('when start point is after closing on a working day', () => {
+                const start  = moment('2021-11-22T19:00:00'); // Monday morning
+
+                // same day, during the day
+                moment('2021-11-22T16:00:00').workingDiff(start, 'calendarDays').should.equal(0);
+                // same day, after close of business
+                moment('2021-11-22T18:00:00').workingDiff(start, 'calendarDays').should.equal(0);
+                // next day, before start of business
+                moment('2021-11-23T08:00:00').workingDiff(start, 'calendarDays').should.equal(1);
+                // next day, during the day
+                moment('2021-11-23T14:00:00').workingDiff(start, 'calendarDays').should.equal(1);
+                // next day, after close of business
+                moment('2021-11-23T19:00:00').workingDiff(start, 'calendarDays').should.equal(1);
+                // friday night
+                moment('2021-11-26T19:00:00').workingDiff(start, 'calendarDays').should.equal(4);
+                // saturday night
+                moment('2021-11-27T19:00:00').workingDiff(start, 'calendarDays').should.equal(4);
+                // sunday night
+                moment('2021-11-28T19:00:00').workingDiff(start, 'calendarDays').should.equal(4);
+                // next monday
+                moment('2021-11-29T11:00:00').workingDiff(start, 'calendarDays').should.equal(5);
+                moment('2021-11-29T18:00:00').workingDiff(start, 'calendarDays').should.equal(5);
+            });
+
+            it('when start point is not a working day', () => {
+                const start  = moment('2021-11-20T08:00:00'); // Saturday morning
+
+                // same day, during the day
+                moment('2021-11-20T16:00:00').workingDiff(start, 'calendarDays').should.equal(0);
+                // same day, after close of business
+                moment('2021-11-20T18:00:00').workingDiff(start, 'calendarDays').should.equal(0);
+                // monday, before start of business
+                moment('2021-11-22T08:00:00').workingDiff(start, 'calendarDays').should.equal(1);
+                // monday, during the day
+                moment('2021-11-22T14:00:00').workingDiff(start, 'calendarDays').should.equal(1);
+                // monday, after close of business
+                moment('2021-11-22T19:00:00').workingDiff(start, 'calendarDays').should.equal(1);
+                // friday night
+                moment('2021-11-26T19:00:00').workingDiff(start, 'calendarDays').should.equal(5);
+                // saturday night
+                moment('2021-11-27T19:00:00').workingDiff(start, 'calendarDays').should.equal(5);
+                // sunday night
+                moment('2021-11-28T19:00:00').workingDiff(start, 'calendarDays').should.equal(5);
+                // next monday
+                moment('2021-11-29T11:00:00').workingDiff(start, 'calendarDays').should.equal(6);
+                moment('2021-11-29T18:00:00').workingDiff(start, 'calendarDays').should.equal(6);
+            });
+        });
+
+        describe('generated tests', () => {
+
+            it('f(a,b) + f(b,c) === f(a,c)', () => {
+                let i = 0;
+                while (i < 20) {
+                    const a = randomDate();
+                    const b = randomDate();
+                    const c = randomDate();
+                    (a.workingDiff(b, 'calendarDays') + b.workingDiff(c, 'calendarDays')).should.equal(a.workingDiff(c, 'calendarDays'));
+                    i++;
+                }
+            });
+
+            it('f(a,b) === -f(b,a)', () => {
+                let i = 0;
+                while (i < 20) {
+                    const a = randomDate();
+                    const b = randomDate();
+                    a.workingDiff(b, 'calendarDays').should.equal(-1 * b.workingDiff(a, 'calendarDays'));
+                    i++;
+                }
+            });
+
+            it('a.addWorkingDays(b).workingDiff(a) === b', () => {
+                let i = 0;
+                while (i < 20) {
+                    const a = randomDate();
+                    const b = a.clone(); // clone because adding working time mutates a
+                    const n = Math.floor(50 * Math.random());
+                    a.addWorkingTime(n, 'days').workingDiff(b, 'calendarDays').should.equal(n);
+                    i++;
+                }
+            });
+
         });
 
     });


### PR DESCRIPTION
Adds support for calculating the difference between two dates purely in terms of calendar days and without concern for the times within a datetime relative to the working hours that day.